### PR TITLE
Not everything needs to be an arrow function

### DIFF
--- a/src/drawing.ts
+++ b/src/drawing.ts
@@ -1,10 +1,10 @@
 import { paddle_is_pulling } from './gameplay'
 import { GameState, Paddle, Puck } from './state'
 
-export const draw_game = (
+export function draw_game(
     ctx: CanvasRenderingContext2D,
     game_state: GameState
-): void => {
+): void {
     ctx.clearRect(0, 0, game_state.width, game_state.height)
     draw_paddle(ctx, game_state, game_state.paddle_l)
     draw_paddle(ctx, game_state, game_state.paddle_r)
@@ -28,18 +28,18 @@ export const draw_game = (
     }
 }
 
-const draw_paddle = (
+function draw_paddle(
     ctx: CanvasRenderingContext2D,
     game_state: GameState,
     paddle: Paddle
-): void => {
+): void {
     ctx.fillStyle = paddle_is_pulling(game_state, paddle)
         ? 'yellow'
         : 'limegreen'
     ctx.fillRect(paddle.left, paddle.top, paddle.width, paddle.height)
 }
 
-const draw_puck = (ctx: CanvasRenderingContext2D, puck: Puck): void => {
+function draw_puck(ctx: CanvasRenderingContext2D, puck: Puck): void {
     ctx.fillStyle = 'magenta'
     ctx.fillRect(
         Math.round(puck.left),
@@ -49,13 +49,13 @@ const draw_puck = (ctx: CanvasRenderingContext2D, puck: Puck): void => {
     )
 }
 
-const paint_text = (
+function paint_text(
     ctx: CanvasRenderingContext2D,
     text: string,
     style: string,
     x: number,
     y: number
-): void => {
+): void {
     ctx.font = style
     ctx.textAlign = 'center'
     ctx.fillStyle = 'white'

--- a/src/gameplay.ts
+++ b/src/gameplay.ts
@@ -2,12 +2,12 @@ import { InputMap } from './input'
 import { GameMode, GameState, Paddle, Puck } from './state'
 import { Velocity } from './velocity'
 
-export const init_game = (
+export function init_game(
     game_mode: GameMode,
     width: number,
     height: number,
     inputs: InputMap
-): GameState => {
+): GameState {
     const center_x = width / 2
     const center_y = height / 2
     const paddle_width = 20
@@ -48,14 +48,14 @@ export const init_game = (
     return pong
 }
 
-const init_paddle = (
+function init_paddle(
     left: number,
     top: number,
     width: number,
     height: number,
     center_x: number,
     puck_width: number
-): Paddle => {
+): Paddle {
     const paddle = new Paddle(left, top, width, height)
     if (paddle.center_x < center_x) {
         paddle.left_boundary = 0
@@ -80,10 +80,10 @@ const init_puck = (
     return puck
 }
 
-export const paddle_is_pulling = (
+export function paddle_is_pulling(
     game_state: GameState,
     paddle: Paddle
-): boolean => {
+): boolean {
     // Paddle exerts attractive force on puck when moving
     // in any direction: ((down XOR up) OR (left XOR right)).
     // The xors are because both can be true but that results
@@ -110,13 +110,13 @@ export const paddle_is_pulling = (
     )
 }
 
-export const input_tick = (game_state: GameState) => {
+export function input_tick(game_state: GameState) {
     for (const [side, input] of game_state.inputs) {
         input.tick(game_state.paddles[side], game_state)
     }
 }
 
-export const gameplay_tick = (game_state: GameState) => {
+export function gameplay_tick(game_state: GameState) {
     const paddles = [game_state.paddle_l, game_state.paddle_r]
     const puck = game_state.puck
 
@@ -165,11 +165,11 @@ export const gameplay_tick = (game_state: GameState) => {
     }
 }
 
-const update_paddle_position = (
+function update_paddle_position(
     game_state: GameState,
     paddle: Paddle,
     puck: Puck
-): void => {
+): void {
     // Apply paddle movement (and apply to puck too, if paddle paddle's
     // grabbing it)
     if (paddle.moving_down && paddle.bottom < game_state.height) {
@@ -200,11 +200,11 @@ const update_paddle_position = (
     }
 }
 
-const check_if_paddle_has_grabbed_puck = (
+function check_if_paddle_has_grabbed_puck(
     game_state: GameState,
     paddle: Paddle,
     puck: Puck
-): void => {
+): void {
     const should_apply_grabbing_this_tick =
         game_state.game_mode.grabbing && paddle.trying_to_grab
     if (should_apply_grabbing_this_tick && puck.grabbed_by === undefined) {
@@ -216,10 +216,10 @@ const check_if_paddle_has_grabbed_puck = (
     }
 }
 
-export const compute_puck_bounce_with_paddle = (
+export function compute_puck_bounce_with_paddle(
     paddle: Paddle,
     puck: Puck
-): void => {
+): void {
     let x_overlap: number,
         y_overlap: number,
         x_teleport: number,
@@ -290,11 +290,11 @@ export const compute_puck_bounce_with_paddle = (
     }
 }
 
-const update_puck_position = (
+function update_puck_position(
     puck: Puck,
     paddles: Paddle[],
     game_state: GameState
-): void => {
+): void {
     // Don't move if grabbed -- paddle will apply
     // movement (but keep velocity for when it's released)
     if (puck.grabbed_by !== undefined) return

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,3 @@
 export const random_bool = (): boolean => Math.round(Math.random()) == 1
 
-export const hypot = (x: number, y: number): number => {
-    return Math.sqrt(x * x + y * y)
-}
+export const hypot = (x: number, y: number): number => Math.sqrt(x * x + y * y)


### PR DESCRIPTION
Use arrow functions only when either:
- I intentionally want to inherit the lexical bindings of the defining scope, or the type checking conditions (e.g. I learned that interestingly, using an arrow function seems to make the function inherit Typescript's awareness of whether a nullable variable has already been null-checked, whereas if you use a normal function, even though the variable is still getting closured in from the defining scope, you must repeat the null check again inside the new function);
- they make the code more readable e.g. if the function is almost more of a macro and just wants to return a single expression.