### PR TITLE
Implement keyboard capture

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
                 border: 3px inset #666;
                 background-color: black;
             }
-            .hidden_panel {
+            .hidden_ui {
                 display: none;
             }
         </style>
@@ -60,11 +60,11 @@
             <div>
                 <label>
                     <input type="checkbox" id="grabbing_mode" />
-                    Enable Grabbing
+                    (<u>1</u>) Enable Grabbing
                 </label>
                 <label>
                     <input type="checkbox" id="magnetic_mode" />
-                    Enable Magnetic Paddles
+                    (<u>2</u>) Enable Magnetic Paddles
                 </label>
             </div>
         </header>
@@ -102,7 +102,7 @@
                         Switch to computer player
                     </button>
                 </div>
-                <div class="ai_panel hidden_panel">
+                <div class="ai_panel hidden_ui">
                     <button
                         class="mode_switch"
                         data-to="human"
@@ -114,7 +114,7 @@
             </div>
             <canvas id="canvas" width="400" height="600"></canvas>
             <div class="sidebar">
-                <div class="help hidden_panel">
+                <div class="help hidden_ui">
                     <h2>Right Paddle:</h2>
                     <table>
                         <tr>
@@ -158,6 +158,12 @@
             </div>
         </main>
         <footer>
+            <p id="keyboard_not_captured_message">
+                <button>Begin/Resume Game</button>
+            </p>
+            <p id="keyboard_captured_message">
+                Keyboard input captured; ESC to pause game and un-capture
+            </p>
             <p>
                 <a href="https://github.com/linusrachlis/the-pong-variations/"
                     >Source Code</a


### PR DESCRIPTION
This addresses issue #19. However, main.ts is getting quite unweildy with spaghetti state management. In addition, there is a conceptual issue becoming clear between game-rendered input prompts and DOM-level input prompts. E.g. in the game-over state, the game renders the message "Space to restart," but now that only works if the game is not "paused," aka input is being captured. As another example, the hotkeys identified by the game-mode checkbox labels only work when input is captured, but that's not clear from looking at them.

The plan for the state management issue is to rewrite the UI in React, which will be the next bit of work.

I'm not sure OTTOMH what to do about the conceptual issue, but I think clarifying state management may help in thinking it through.